### PR TITLE
Added more SDL2 functions; Moving functions

### DIFF
--- a/lib/SDL2/Raw.pm
+++ b/lib/SDL2/Raw.pm
@@ -1,12 +1,21 @@
 use NativeCall;
 
 my Str $lib;
-BEGIN {
-    if $*VM.config<dll> ~~ /dll/ {
-        $lib = 'SDL2';
-    } else {
-        $lib = 'libSDL2';
-    }
+if $*VM.config<dll> ~~ /dll/ {
+  # Windows-specific library name.
+  # What should be looked for: SDL2.dll
+  $lib = 'SDL2';
+} else if $*VM.config<dll> ~~ /dylib/ {
+  # Mac-specific library name.
+  # What should be looked for: libSDL2.dylib
+  # TODO: Test that this branch is properly working.
+  $lib = 'SDL2';
+} else if $*VM.config<dll> ~~ /so/ {
+  # Linux-specific library name.
+  # What should be looked for: libSDL2.so
+  $lib = 'SDL2';
+} else {
+  die "Unsupported platform. Please add a branch to $FILE:$LINE for your platform dynamic library type."
 }
 
 

--- a/lib/SDL2/Raw.pm
+++ b/lib/SDL2/Raw.pm
@@ -5,11 +5,18 @@ BEGIN {
     if $*VM.config<dll> ~~ /dll/ {
         $lib = 'SDL2';
     } else {
-        $lib = 'SDL2';
+        $lib = 'libSDL2';
     }
 }
 
-class SDL_Point is repr('CStruct') is rw {
+
+################################################################################
+# CLASSES
+################################################################################
+
+# Classes that contain retrievable/useful information for the rest of the program,
+# or that are commonly used as arguments that need to be constructed.
+class SDL_Point32 is repr('CStruct') is rw {
     # positional
     multi method new(Real $x, Real $y) { self.bless(:$x.Int, :$y.Int) }
     multi method new(Complex $complex) { self.bless(:x($complex.re), :y($complex.im)) }
@@ -23,11 +30,11 @@ class SDL_Point is repr('CStruct') is rw {
 
 class SDL_Rect is repr('CStruct') is rw {
     # positional
-    multi method new(int $x, int $y, int $w, int $h) { self.bless(:$x, :$y, :$w, :$h) }
+    multi method new(int32 $x, int32 $y, int32 $w, int32 $h) { self.bless(:$x, :$y, :$w, :$h) }
     multi method new(Int(Real) $x, Int(Real) $y, Int(Real) $w, Int(Real) $h) { self.bless(:$x, :$y, :$w, :$h) }
 
     # named
-    multi method new(int :$x!, int :$y!, int :$w!, int :$h!) { self.bless(:$x, :$y, :$w, :$h) }
+    multi method new(int32 :$x!, int32 :$y!, int32 :$w!, int32 :$h!) { self.bless(:$x, :$y, :$w, :$h) }
     multi method new(Int(Real) :$x!, Int(Real) :$y!, Int(Real) :$w!, Int(Real) :$h!) { self.bless(:$x, :$y, :$w, :$h) }
 
     has int32 $.x;
@@ -35,6 +42,7 @@ class SDL_Rect is repr('CStruct') is rw {
     has int32 $.w;
     has int32 $.h;
 }
+
 class SDL_DisplayMode is repr('CStruct') is rw {
     has uint32   $.format;
     has int32    $.w;
@@ -42,61 +50,6 @@ class SDL_DisplayMode is repr('CStruct') is rw {
     has int32    $.refresh_rate;
     has Pointer  $.driverdata;
 }
-
-enum SDL_INIT (
-    :TIMER(0x1),
-    :AUDIO(0x10),
-    :VIDEO(0x20),
-    :JOYSTICK(0x200),
-    :HAPTIC(0x1000),
-    :GAMECONTROLLER(0x2000),
-    :EVENTS(0x4000),
-    :NOPARACHUTE(0x100000)
-);
-
-sub SDL_Init(int32 $flags) is native($lib) is export {*}
-sub SDL_Quit() is native($lib) is export {*}
-
-class SDL_Window is repr('CPointer') { }
-
-enum SDL_WindowFlags (
-    :FULLSCREEN(0x00000001),
-    :OPENGL(0x00000002),
-    :SHOWN(0x00000004),
-    :HIDDEN(0x00000008),
-    :BORDERLESS(0x00000010),
-    :RESIZABLE(0x00000020),
-    :MINIMIZED(0x00000040),
-    :MAXIMIZED(0x00000080),
-    :INPUT_GRABBED(0x00000100),
-    :INPUT_FOCUS(0x00000200),
-    :MOUSE_FOCUS(0x00000400),
-    :FULLSCREEN_DESKTOP(0x00001001),
-    :FOREIGN(0x00000800),
-    :ALLOW_HIGHDPI(0x00002000),
-    :MOUSE_CAPTURE(0x00004000),
-);
-
-enum WindowEventID (
-    'WINDOW_EVENT_NONE',           # Never used
-    'EVENT_SHOWN',          # Window has been shown
-    'EVENT_HIDDEN',         # Window has been hidden
-    'EXPOSED',        # Window has been exposed and should be redrawn
-    'MOVED',          # Window has been moved to data1', data2
-    'RESIZED',        # Window has been resized to data1xdata2
-    'SIZE_CHANGED',   # The window size has changed', either as a result of an API call or through the system or user changing the window size.
-    'EVENT_MINIMIZED',      # Window has been minimized
-    'EVENT_MAXIMIZED',      # Window has been maximized
-    'RESTORED',       # Window has been restored to normal size and position
-    'ENTER',          # Window has gained mouse focus
-    'LEAVE',          # Window has lost mouse focus
-    'FOCUS_GAINED',   # Window has gained keyboard focus
-    'FOCUS_LOST',     # Window has lost keyboard focus
-    'CLOSE',          # The window manager requests that the window be closed
-);
-
-our constant SDL_WINDOWPOS_UNDEFINED_MASK = 0x1FFF0000;
-our constant SDL_WINDOWPOS_CENTERED_MASK = 0x2FFF0000;
 
 class SDL_RendererInfo is repr('CStruct') is rw {
     has Str $.name;
@@ -108,215 +61,7 @@ class SDL_RendererInfo is repr('CStruct') is rw {
     has int32 $.max_texture_height;
 }
 
-enum SDL_RendererFlags (
-    :SOFTWARE(1),
-    :ACCELERATED(2),
-    :PRESENTVSYNC(4),
-    :TARGETTEXTURE(8),
-);
-
-enum SDL_TextureAccess <
-    STATIC
-    STREAMING
-    TARGET
->;
-
-enum SDL_TextureModulate <
-    TEXTURE_MODULATE_NONE
-    COLOR
-    ALPHA
->;
-
-enum SDL_RendererFlip <
-    RENDERER_FLIP_NONE
-    HORIZONTAL
-    VERTICAL
->;
-
-class SDL_Renderer is repr('CPointer') { }
-
-class SDL_Texture is repr('CPointer') { }
-
-sub SDL_GetNumRenderDrivers()
-        returns int32
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_GetRenderDriverInfo(int32 $index, SDL_RendererInfo $info)
-        returns int32
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_CreateWindowAndRenderer(int32 $width, int32 $height,
-                                int32 $flags,
-                                Pointer[SDL_Window] $win, Pointer[SDL_Renderer] $renderer)
-        returns int32
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_CreateRenderer(SDL_Window $win, int32 $index, int32 $flags)
-        returns SDL_Renderer
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_CreateTexture(SDL_Renderer $renderer, int32 $format, int32 $access, int32 $w, int32 $h)
-        returns SDL_Texture
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_SetRenderTarget(SDL_Renderer $renderer, SDL_Texture $texture)
-        returns int32
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_UpdateTexture(SDL_Texture $tex, SDL_Rect $rect, Pointer $data, int32 $pitch)
-        returns int32
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_SetTextureBlendMode(SDL_Texture $tex, int32 $blendmode)
-        returns int32
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_GetTextureBlendMode(SDL_Texture $tex, Pointer[int32] $blendmode)
-        returns int32
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_RenderSetLogicalSize(SDL_Renderer $renderer, int32 $w, int32 $h)
-        returns int32
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_RenderGetLogicalSize(SDL_Renderer $renderer, Pointer[int32] $w, Pointer[int32] $h)
-        is native($lib)
-        is export {*}
-
-sub SDL_SetRenderDrawColor(SDL_Renderer $renderer, int8 $r, int8 $g, int8 $b, int8 $a)
-        returns int32
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_SetTextureColorMod(SDL_Texture $texture, int8 $r, int8 $g, int8 $b) returns int32 is native($lib) is export {*}
-
-sub SDL_GetRenderDrawColor(SDL_Renderer $renderer, Pointer[uint8] $r, Pointer[uint8] $g, Pointer[uint8] $b, Pointer[uint8] $a) returns int32 is native($lib) is export {*}
-
-sub SDL_SetRenderDrawBlendMode(SDL_Renderer $renderer, int32 $blendmode)
-        is native($lib)
-        is export
-        {*}
-
-sub SDL_RenderCopy(SDL_Renderer $renderer, SDL_Texture $src, SDL_Rect $srcrect, SDL_Rect $destrect) returns int32 is native($lib) is export {*}
-sub SDL_RenderCopyEx(SDL_Renderer $renderer, SDL_Texture $src, SDL_Rect $srcrect, SDL_Rect $destrect, num64 $angle, SDL_Point $center, int32 $flip) returns int32 is native($lib) is export {*}
-
-sub SDL_RenderClear(SDL_Renderer $renderer) returns int32 is native($lib) is export {*}
-sub SDL_RenderPresent(SDL_Renderer $renderer) is native($lib) is export {*}
-
-sub SDL_RenderDrawPoint(SDL_Renderer $renderer, int32 $x, int32 $y) returns int32 is native($lib) is export {*}
-sub SDL_RenderDrawLine(SDL_Renderer $renderer, int32 $x, int32 $y, int32 $x2, int32 $y2) returns int32 is native($lib) is export {*}
-
-sub SDL_RenderDrawRect(SDL_Renderer $renderer, SDL_Rect $rect) returns int32 is native($lib) is export {*}
-sub SDL_RenderFillRect(SDL_Renderer $renderer, SDL_Rect $rect) returns int32 is native($lib) is export {*}
-
-sub SDL_DestroyTexture(SDL_Texture $texture) is native($lib) is export {*}
-sub SDL_DestroyRenderer(SDL_Renderer $renderer) is native($lib) is export {*}
-
-sub SDL_GL_BindTexture(SDL_Texture $texture, Pointer[num32] $texw, Pointer[num32] $texh) returns int32 is native($lib) is export {*}
-sub SDL_GL_UnBindTexture(SDL_Texture $texture) returns int32 is native($lib) is export {*}
-
-sub SDL_VideoInit(Str $drivername) returns int32 is native($lib) is export {*}
-sub SDL_VideoQuit() is native($lib) is export {*}
-
-sub SDL_GetNumVideoDrivers() returns int32 is native($lib) is export {*}
-sub SDL_GetVideoDriver(int32 $index) returns Str is native($lib) is export {*}
-sub SDL_GetCurrentVideoDriver() returns Str is native($lib) is export {*}
-
-sub SDL_GetNumVideoDisplays() returns int32 is native($lib) is export {*}
-sub SDL_GetDisplayName(int32 $index) returns Str is native($lib) is export {*}
-sub SDL_GetDisplayBounds(int32 $index, SDL_Rect $rect) returns int32 is native($lib) is export {*}
-
-sub SDL_CreateWindow(Str $title, int32 $x, int32 $y, int32 $w, int32 $h, int32 $flags) returns SDL_Window is native($lib) is export {*}
-sub SDL_SetWindowTitle(SDL_Window $window, Str $title) returns Str is native($lib) is export {*}
-sub SDL_GetWindowTitle(SDL_Window $window) returns Str is native($lib) is export {*}
-
-sub SDL_UpdateWindowSurface(SDL_Window $window) returns int32 is native($lib) is export {*}
-
-sub SDL_SetWindowGrab(SDL_Window $window, int32 $grabbed) is native($lib) is export {*}
-sub SDL_GetWindowGrab(SDL_Window $window) returns int32 is native($lib) is export {*}
-
-
-enum SDL_EventType (
-   FIRSTEVENT     => 0,
-
-   QUIT           => 0x100,
-
-   "APP_TERMINATING",
-   "APP_LOWMEMORY",
-   "APP_WILLENTERBACKGROUND",
-   "APP_DIDENTERBACKGROUND",
-   "APP_WILLENTERFOREGROUND",
-   "APP_DIDENTERFOREGROUND",
-
-   WINDOWEVENT    => 0x200,
-   "SYSWMEVENT",
-
-   KEYDOWN        => 0x300,
-   "KEYUP",
-   "TEXTEDITING",
-   "TEXTINPUT",
-
-   MOUSEMOTION    => 0x400,
-   "MOUSEBUTTONDOWN",
-   "MOUSEBUTTONUP",
-   "MOUSEWHEEL",
-
-   JOYAXISMOTION  => 0x600,
-   "JOYBALLMOTION",
-   "JOYHATMOTION",
-   "JOYBUTTONDOWN",
-   "JOYBUTTONUP",
-   "JOYDEVICEADDED",
-   "JOYDEVICEREMOVED",
-
-   CONTROLLERAXISMOTION  => 0x650,
-   "CONTROLLERBUTTONDOWN",
-   "CONTROLLERBUTTONUP",
-   "CONTROLLERDEVICEADDED",
-   "CONTROLLERDEVICEREMOVED",
-   "CONTROLLERDEVICEREMAPPED",
-
-   FINGERDOWN      => 0x700,
-   "FINGERUP",
-   "FINGERMOTION",
-
-   DOLLARGESTURE   => 0x800,
-   "DOLLARRECORD",
-   "MULTIGESTURE",
-
-   CLIPBOARDUPDATE => 0x900,
-
-   DROPFILE        => 0x1000,
-
-   RENDER_TARGETS_RESET => 0x2000,
-   "RENDER_DEVICE_RESET",
-
-   USEREVENT    => 0x8000,
-
-   LASTEVENT    => 0xFFFF,
-);
-
+# TODO: Rewrite event handling to use native union type.
 class SDL_Event is repr('CStruct') is rw {
     has uint32 $.type;
     has uint32 $.timestamp;
@@ -385,43 +130,160 @@ class SDL_MouseWheelEvent is repr('CStruct') is rw {
     has int32  $.y;
 }
 
-sub SDL_PollEvent(SDL_Event $event) returns int32 is native($lib) is export {*}
-sub SDL_WaitEvent(SDL_Event $event) returns int32 is native($lib) is export {*}
-sub SDL_WaitEventTimeout(SDL_Event $event, int32 $timeout) returns int32 is native($lib) is export {*}
-
-sub SDL_CastEvent(SDL_Event $event) is export {
-    given $event.type {
-        when WINDOWEVENT {
-            nativecast(SDL_WindowEvent, $event)
-        }
-        when KEYDOWN | KEYUP {
-            nativecast(SDL_KeyboardEvent, $event)
-        }
-        when MOUSEBUTTONUP | MOUSEBUTTONDOWN {
-            nativecast(SDL_MouseButtonEvent, $event)
-        }
-        when MOUSEMOTION {
-            nativecast(SDL_MouseMotionEvent, $event)
-        }
-        when MOUSEWHEEL {
-            nativecast(SDL_MouseWheelEvent, $event)
-        }
-        default {
-            $event
-        }
-    }
+class SDL_QuitEvent is repr('CStruct') is rw {
+  has uint32 $.type;
+  has uint32 $.timestamp;
 }
 
-our constant SDL_QUERY   = -1;
-our constant SDL_IGNORE  =  0;
-our constant SDL_DISABLE =  0;
-our constant SDL_ENABLE  =  1;
+# "Opaque" pointer classes.
+class SDL_Window is repr('CPointer') { }
+class SDL_Renderer is repr('CPointer') { }
+class SDL_GLContext is repr('CPointer') { }
+class SDL_Texture is repr('CPointer') { }
 
-sub SDL_EventState(int32 $type, int32 $state) returns uint8 is native($lib) is export {*}
 
-my sub _pxfmt($type, $order, $layout, $bits, $bytes) {
-    (1 +< 28) +| ($type +< 24) +| ($order +< 20) +| ($layout +< 16) +| ($bits +< 8) +| $bytes
-}
+################################################################################
+# ENUMS
+################################################################################
+
+enum SDL_INIT (
+    :TIMER(0x1),
+    :AUDIO(0x10),
+    :VIDEO(0x20),
+    :JOYSTICK(0x200),
+    :HAPTIC(0x1000),
+    :GAMECONTROLLER(0x2000),
+    :EVENTS(0x4000),
+    :NOPARACHUTE(0x100000)
+);
+
+enum SDL_WindowFlags (
+    :FULLSCREEN(0x00000001),
+    :OPENGL(0x00000002),
+    :SHOWN(0x00000004),
+    :HIDDEN(0x00000008),
+    :BORDERLESS(0x00000010),
+    :RESIZABLE(0x00000020),
+    :MINIMIZED(0x00000040),
+    :MAXIMIZED(0x00000080),
+    :INPUT_GRABBED(0x00000100),
+    :INPUT_FOCUS(0x00000200),
+    :MOUSE_FOCUS(0x00000400),
+    :FULLSCREEN_DESKTOP(0x00001001),
+    :FOREIGN(0x00000800),
+    :ALLOW_HIGHDPI(0x00002000),
+    :MOUSE_CAPTURE(0x00004000),
+);
+
+enum WindowEventID (
+    'WINDOW_EVENT_NONE',           # Never used
+    'EVENT_SHOWN',          # Window has been shown
+    'EVENT_HIDDEN',         # Window has been hidden
+    'EXPOSED',        # Window has been exposed and should be redrawn
+    'MOVED',          # Window has been moved to data1', data2
+    'RESIZED',        # Window has been resized to data1xdata2
+    'SIZE_CHANGED',   # The window size has changed', either as a result of an API call or through the system or user changing the window size.
+    'EVENT_MINIMIZED',      # Window has been minimized
+    'EVENT_MAXIMIZED',      # Window has been maximized
+    'RESTORED',       # Window has been restored to normal size and position
+    'ENTER',          # Window has gained mouse focus
+    'LEAVE',          # Window has lost mouse focus
+    'FOCUS_GAINED',   # Window has gained keyboard focus
+    'FOCUS_LOST',     # Window has lost keyboard focus
+    'CLOSE',          # The window manager requests that the window be closed
+);
+
+our constant SDL_WINDOWPOS_UNDEFINED_MASK = 0x1FFF0000;
+our constant SDL_WINDOWPOS_CENTERED_MASK = 0x2FFF0000;
+
+enum SDL_RendererFlags (
+    :SOFTWARE(1),
+    :ACCELERATED(2),
+    :PRESENTVSYNC(4),
+    :TARGETTEXTURE(8),
+);
+
+enum SDL_TextureAccess <
+    STATIC
+    STREAMING
+    TARGET
+>;
+
+enum SDL_TextureModulate <
+    TEXTURE_MODULATE_NONE
+    COLOR
+    ALPHA
+>;
+
+enum SDL_RendererFlip <
+    RENDERER_FLIP_NONE
+    HORIZONTAL
+    VERTICAL
+>;
+
+enum SDL_EventType (
+   FIRSTEVENT     => 0,
+
+   QUIT           => 0x100,
+
+   "APP_TERMINATING",
+   "APP_LOWMEMORY",
+   "APP_WILLENTERBACKGROUND",
+   "APP_DIDENTERBACKGROUND",
+   "APP_WILLENTERFOREGROUND",
+   "APP_DIDENTERFOREGROUND",
+
+   WINDOWEVENT    => 0x200,
+   "SYSWMEVENT",
+
+   KEYDOWN        => 0x300,
+   "KEYUP",
+   "TEXTEDITING",
+   "TEXTINPUT",
+   "KEYMAPCHANGED",
+
+   MOUSEMOTION    => 0x400,
+   "MOUSEBUTTONDOWN",
+   "MOUSEBUTTONUP",
+   "MOUSEWHEEL",
+
+   JOYAXISMOTION  => 0x600,
+   "JOYBALLMOTION",
+   "JOYHATMOTION",
+   "JOYBUTTONDOWN",
+   "JOYBUTTONUP",
+   "JOYDEVICEADDED",
+   "JOYDEVICEREMOVED",
+
+   CONTROLLERAXISMOTION  => 0x650,
+   "CONTROLLERBUTTONDOWN",
+   "CONTROLLERBUTTONUP",
+   "CONTROLLERDEVICEADDED",
+   "CONTROLLERDEVICEREMOVED",
+   "CONTROLLERDEVICEREMAPPED",
+
+   FINGERDOWN      => 0x700,
+   "FINGERUP",
+   "FINGERMOTION",
+
+   DOLLARGESTURE   => 0x800,
+   "DOLLARRECORD",
+   "MULTIGESTURE",
+
+   CLIPBOARDUPDATE => 0x900,
+
+   DROPFILE        => 0x1000,
+
+   AUDIODEVICEADDED => 0x1100,
+   "AUDIODEVICEREMOVED",
+
+   RENDER_TARGETS_RESET => 0x2000,
+   "RENDER_DEVICE_RESET",
+
+   USEREVENT    => 0x8000,
+
+   LASTEVENT    => 0xFFFF,
+);
 
 enum SDL_Pixeltype <
         PIXELTYPE_UNKNOWN
@@ -478,6 +340,222 @@ enum SDL_PackedLayout <
         PACKEDLAYOUT_2101010
         PACKEDLAYOUT_1010102
     >;
+
+enum SDL_GLAttr is export <
+    RED_SIZE
+    GREEN_SIZE
+    BLUE_SIZE
+    ALPHA_SIZE
+    BUFFER_SIZE
+    DOUBLEBUFFER
+    DEPTH_SIZE
+    STENCIL_SIZE
+    ACCUM_RED_SIZE
+    ACCUM_GREEN_SIZE
+    ACCUM_BLUE_SIZE
+    ACCUM_ALPHA_SIZE
+    STEREO
+    MULTISAMPLEBUFFERS
+    MULTISAMPLESAMPLES
+    ACCELERATED_VISUAL
+    RETAINED_BACKING
+    CONTEXT_MAJOR_VERSION
+    CONTEXT_MINOR_VERSION
+    CONTEXT_EGL
+    CONTEXT_FLAGS
+    CONTEXT_PROFILE_MASK
+    SHARE_WITH_CURRENT_CONTEXT
+    FRAMEBUFFER_SRGB_CAPABLE
+>;
+
+enum SDL_GLProfile (
+    :CONTEXT_PROFILE_CORE(0x0001),
+    :CONTEXT_PROFILE_COMPATIBILITY(0x0002),
+    :CONTEXT_PROFILE_ES(0x0004)
+);
+
+
+################################################################################
+# FUNCTIONS
+################################################################################
+
+# Initialization/shutdown
+sub SDL_Init(int32 $flags) is native($lib, v1.1.0) is export {*}
+sub SDL_Quit() is native($lib, v1.1.0) is export {*}
+sub SDL_GetError() returns Str is native($lib, v1.1.0) is export {*}
+
+# Window functions
+sub SDL_CreateWindow(Str $title, int32 $x, int32 $y, int32 $w, int32 $h, int32 $flags) returns SDL_Window is native($lib, v1.1.0) is export {*}
+sub SDL_CreateWindowAndRenderer(int32 $width, int32 $height,
+                                int32 $flags,
+                                Pointer[SDL_Window] $win, Pointer[SDL_Renderer] $renderer)
+        returns int32
+        is native($lib, v1.1.0)
+        is export {*}
+sub SDL_DestroyWindow(SDL_Window $window) is native($lib, v1.1.0) is export {*}
+sub SDL_SetWindowTitle(SDL_Window $window, Str $title) returns Str is native($lib, v1.1.0) is export {*}
+sub SDL_GetWindowTitle(SDL_Window $window) returns Str is native($lib, v1.1.0) is export {*}
+
+sub SDL_UpdateWindowSurface(SDL_Window $window) returns int32 is native($lib, v1.1.0) is export {*}
+
+sub SDL_SetWindowGrab(SDL_Window $window, int32 $grabbed) is native($lib, v1.1.0) is export {*}
+sub SDL_GetWindowGrab(SDL_Window $window) returns int32 is native($lib, v1.1.0) is export {*}
+
+sub SDL_ShowWindow(SDL_Window $window) is native($lib, v1.1.0) is export {*}
+
+# Renderer functions
+sub SDL_CreateRenderer(SDL_Window $win, int32 $index, int32 $flags)
+        returns SDL_Renderer
+        is native($lib, v1.1.0)
+        is export
+        {*}
+
+sub SDL_SetRenderTarget(SDL_Renderer $renderer, SDL_Texture $texture)
+        returns int32
+        is native($lib, v1.1.0)
+        is export
+        {*}
+
+sub SDL_GetNumRenderDrivers()
+        returns int32
+        is native($lib, v1.1.0)
+        is export
+        {*}
+
+sub SDL_GetRenderDriverInfo(int32 $index, SDL_RendererInfo $info)
+        returns int32
+        is native($lib, v1.1.0)
+        is export
+        {*}
+
+sub SDL_RenderSetLogicalSize(SDL_Renderer $renderer, int32 $w, int32 $h)
+        returns int32
+        is native($lib, v1.1.0)
+        is export
+        {*}
+
+sub SDL_RenderGetLogicalSize(SDL_Renderer $renderer, Pointer[int32] $w, Pointer[int32] $h)
+        is native($lib, v1.1.0)
+        is export {*}
+
+sub SDL_SetRenderDrawColor(SDL_Renderer $renderer, int8 $r, int8 $g, int8 $b, int8 $a)
+        returns int32
+        is native($lib, v1.1.0)
+        is export
+        {*}
+
+sub SDL_GetRenderDrawColor(SDL_Renderer $renderer, Pointer[uint8] $r, Pointer[uint8] $g, Pointer[uint8] $b, Pointer[uint8] $a) returns int32 is native($lib, v1.1.0) is export {*}
+
+sub SDL_RenderCopy(SDL_Renderer $renderer, SDL_Texture $src, SDL_Rect $srcrect, SDL_Rect $destrect) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_RenderCopyEx(SDL_Renderer $renderer, SDL_Texture $src, SDL_Rect $srcrect, SDL_Rect $destrect, num32 $angle, SDL_Point32 $center, int32 $flip) returns int32 is native($lib, v1.1.0) is export {*}
+
+sub SDL_RenderClear(SDL_Renderer $renderer) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_RenderPresent(SDL_Renderer $renderer) is native($lib, v1.1.0) is export {*}
+
+sub SDL_RenderDrawPoint(SDL_Renderer $renderer, int32 $x, int32 $y) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_RenderDrawLine(SDL_Renderer $renderer, int32 $x, int32 $y, int32 $x2, int32 $y2) returns int32 is native($lib, v1.1.0) is export {*}
+
+sub SDL_RenderDrawRect(SDL_Renderer $renderer, SDL_Rect $rect) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_RenderFillRect(SDL_Renderer $renderer, SDL_Rect $rect) returns int32 is native($lib, v1.1.0) is export {*}
+
+# Texture functions
+sub SDL_CreateTexture(SDL_Renderer $renderer, int32 $format, int32 $access, int32 $w, int32 $h)
+        returns SDL_Texture
+        is native($lib, v1.1.0)
+        is export
+        {*}
+
+sub SDL_UpdateTexture(SDL_Texture $tex, SDL_Rect $rect, Pointer $data, int32 $pitch)
+        returns int32
+        is native($lib, v1.1.0)
+        is export
+        {*}
+
+sub SDL_SetTextureBlendMode(SDL_Texture $tex, int32 $blendmode)
+        returns int32
+        is native($lib, v1.1.0)
+        is export
+        {*}
+
+sub SDL_GetTextureBlendMode(SDL_Texture $tex, Pointer[int32] $blendmode)
+        returns int32
+        is native($lib, v1.1.0)
+        is export
+        {*}
+
+sub SDL_SetTextureColorMod(SDL_Texture $texture, int8 $r, int8 $g, int8 $b) returns int32 is native($lib, v1.1.0) is export {*}
+
+sub SDL_SetRenderDrawBlendMode(SDL_Renderer $renderer, int32 $blendmode)
+        is native($lib, v1.1.0)
+        is export
+        {*}
+
+sub SDL_DestroyTexture(SDL_Texture $texture) is native($lib, v1.1.0) is export {*}
+sub SDL_DestroyRenderer(SDL_Renderer $renderer) is native($lib, v1.1.0) is export {*}
+
+sub SDL_VideoInit(Str $drivername) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_VideoQuit() is native($lib, v1.1.0) is export {*}
+
+sub SDL_GetNumVideoDrivers() returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_GetVideoDriver(int32 $index) returns Str is native($lib, v1.1.0) is export {*}
+sub SDL_GetCurrentVideoDriver() returns Str is native($lib, v1.1.0) is export {*}
+
+sub SDL_GetNumVideoDisplays() returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_GetDisplayName(int32 $index) returns Str is native($lib, v1.1.0) is export {*}
+sub SDL_GetDisplayBounds(int32 $index, SDL_Rect $rect) returns int32 is native($lib, v1.1.0) is export {*}
+
+# GL Functions
+sub SDL_GL_BindTexture(SDL_Texture $texture, Pointer[num32] $texw, Pointer[num32] $texh) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_GL_UnBindTexture(SDL_Texture $texture) returns int32 is native($lib, v1.1.0) is export {*}
+
+sub SDL_GL_CreateContext(SDL_Window $window) returns SDL_GLContext is native($lib, v1.1.0) is export {*}
+sub SDL_GL_DeleteContext(SDL_GLContext $context) is native($lib, v1.1.0) is export {*}
+sub SDL_GL_MakeCurrent(SDL_Window $window, SDL_GLContext $context) returns int32 is native($lib, v1.1.0) is export {*}
+
+sub SDL_GL_SetAttribute(int32 $attr, int32 $value) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_GL_SwapWindow(SDL_Window $window) is native($lib, v1.1.0) is export {*}
+
+# Event functions
+sub SDL_PollEvent(SDL_Event $event) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_WaitEvent(SDL_Event $event) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_WaitEventTimeout(SDL_Event $event, int32 $timeout) returns int32 is native($lib, v1.1.0) is export {*}
+
+sub SDL_CastEvent(SDL_Event $event) is export {
+  given $event.type {
+    when WINDOWEVENT {
+      nativecast(SDL_WindowEvent, $event)
+    }
+    when KEYDOWN | KEYUP {
+      nativecast(SDL_KeyboardEvent, $event)
+    }
+    when MOUSEBUTTONUP | MOUSEBUTTONDOWN {
+      nativecast(SDL_MouseButtonEvent, $event)
+    }
+    when MOUSEMOTION {
+      nativecast(SDL_MouseMotionEvent, $event)
+    }
+    when MOUSEWHEEL {
+      nativecast(SDL_MouseWheelEvent, $event)
+    }
+    when QUIT {
+      nativecast(SDL_QuitEvent, $event)
+    }
+    default {
+      $event
+    }
+  }
+}
+
+our constant SDL_QUERY   = -1;
+our constant SDL_IGNORE  =  0;
+our constant SDL_DISABLE =  0;
+our constant SDL_ENABLE  =  1;
+
+sub SDL_EventState(int32 $type, int32 $state) returns uint8 is native($lib, v1.1.0) is export {*}
+
+my sub _pxfmt($type, $order, $layout, $bits, $bytes) {
+    (1 +< 28) +| ($type +< 24) +| ($order +< 20) +| ($layout +< 16) +| ($bits +< 8) +| $bytes
+}
 
 our %PIXELFORMAT is export = (
         UNKNOWN => 0,

--- a/lib/SDL2/Raw.pm6
+++ b/lib/SDL2/Raw.pm6
@@ -1,22 +1,33 @@
 use NativeCall;
 
-my Str $lib;
-if $*VM.config<dll> ~~ /dll/ {
-  # Windows-specific library name.
-  # What should be looked for: SDL2.dll
-  $lib = 'SDL2';
-} else if $*VM.config<dll> ~~ /dylib/ {
-  # Mac-specific library name.
-  # What should be looked for: libSDL2.dylib
-  # TODO: Test that this branch is properly working.
-  $lib = 'SDL2';
-} else if $*VM.config<dll> ~~ /so/ {
-  # Linux-specific library name.
-  # What should be looked for: libSDL2.so
-  $lib = 'SDL2';
-} else {
-  die "Unsupported platform. Please add a branch to $FILE:$LINE for your platform dynamic library type."
+my Str $lib = "";
+my &libFunc = sub {$lib};
+BEGIN {
+  if $*VM.config<dll> ~~ /dll/ {
+    # Windows-specific library name.
+    # What should be looked for: SDL2.dll
+
+    # Test the current directory for the dll, which is the most likely place
+    # that it would exist on Windows.
+    if "./SDL2.dll".IO.e {
+      $lib = "./SDL2.dll".IO.abspath;
+    } else {
+      $lib = 'SDL2';
+    }
+  } elsif $*VM.config<dll> ~~ /dylib/ {
+    # Mac-specific library name.
+    # What should be looked for: libSDL2.dylib
+    # TODO: Test that this branch is properly working.
+    $lib = 'SDL2';
+  } elsif $*VM.config<dll> ~~ /so/ {
+    # Linux-specific library name.
+    # What should be looked for: libSDL2.so
+    $lib = 'SDL2';
+  } else {
+    die "Unsupported platform. Please add a branch to $?FILE:$?LINE for your platform dynamic library type."
+  }
 }
+say "lib: $lib";
 
 
 ################################################################################
@@ -389,145 +400,145 @@ enum SDL_GLProfile (
 ################################################################################
 
 # Initialization/shutdown
-sub SDL_Init(int32 $flags) is native($lib, v1.1.0) is export {*}
-sub SDL_Quit() is native($lib, v1.1.0) is export {*}
-sub SDL_GetError() returns Str is native($lib, v1.1.0) is export {*}
+sub SDL_Init(int32 $flags) is native($lib) is export {*}
+sub SDL_Quit() is native($lib) is export {*}
+sub SDL_GetError() returns Str is native($lib) is export {*}
 
 # Window functions
-sub SDL_CreateWindow(Str $title, int32 $x, int32 $y, int32 $w, int32 $h, int32 $flags) returns SDL_Window is native($lib, v1.1.0) is export {*}
+sub SDL_CreateWindow(Str $title, int32 $x, int32 $y, int32 $w, int32 $h, int32 $flags) returns SDL_Window is native($lib) is export {*}
 sub SDL_CreateWindowAndRenderer(int32 $width, int32 $height,
                                 int32 $flags,
                                 Pointer[SDL_Window] $win, Pointer[SDL_Renderer] $renderer)
         returns int32
-        is native($lib, v1.1.0)
+        is native($lib)
         is export {*}
-sub SDL_DestroyWindow(SDL_Window $window) is native($lib, v1.1.0) is export {*}
-sub SDL_SetWindowTitle(SDL_Window $window, Str $title) returns Str is native($lib, v1.1.0) is export {*}
-sub SDL_GetWindowTitle(SDL_Window $window) returns Str is native($lib, v1.1.0) is export {*}
+sub SDL_DestroyWindow(SDL_Window $window) is native($lib) is export {*}
+sub SDL_SetWindowTitle(SDL_Window $window, Str $title) returns Str is native($lib) is export {*}
+sub SDL_GetWindowTitle(SDL_Window $window) returns Str is native($lib) is export {*}
 
-sub SDL_UpdateWindowSurface(SDL_Window $window) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_UpdateWindowSurface(SDL_Window $window) returns int32 is native($lib) is export {*}
 
-sub SDL_SetWindowGrab(SDL_Window $window, int32 $grabbed) is native($lib, v1.1.0) is export {*}
-sub SDL_GetWindowGrab(SDL_Window $window) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_SetWindowGrab(SDL_Window $window, int32 $grabbed) is native($lib) is export {*}
+sub SDL_GetWindowGrab(SDL_Window $window) returns int32 is native($lib) is export {*}
 
-sub SDL_ShowWindow(SDL_Window $window) is native($lib, v1.1.0) is export {*}
+sub SDL_ShowWindow(SDL_Window $window) is native($lib) is export {*}
 
 # Renderer functions
 sub SDL_CreateRenderer(SDL_Window $win, int32 $index, int32 $flags)
         returns SDL_Renderer
-        is native($lib, v1.1.0)
+        is native($lib)
         is export
         {*}
 
 sub SDL_SetRenderTarget(SDL_Renderer $renderer, SDL_Texture $texture)
         returns int32
-        is native($lib, v1.1.0)
+        is native($lib)
         is export
         {*}
 
 sub SDL_GetNumRenderDrivers()
         returns int32
-        is native($lib, v1.1.0)
+        is native($lib)
         is export
         {*}
 
 sub SDL_GetRenderDriverInfo(int32 $index, SDL_RendererInfo $info)
         returns int32
-        is native($lib, v1.1.0)
+        is native($lib)
         is export
         {*}
 
 sub SDL_RenderSetLogicalSize(SDL_Renderer $renderer, int32 $w, int32 $h)
         returns int32
-        is native($lib, v1.1.0)
+        is native($lib)
         is export
         {*}
 
 sub SDL_RenderGetLogicalSize(SDL_Renderer $renderer, Pointer[int32] $w, Pointer[int32] $h)
-        is native($lib, v1.1.0)
+        is native($lib)
         is export {*}
 
 sub SDL_SetRenderDrawColor(SDL_Renderer $renderer, int8 $r, int8 $g, int8 $b, int8 $a)
         returns int32
-        is native($lib, v1.1.0)
+        is native($lib)
         is export
         {*}
 
-sub SDL_GetRenderDrawColor(SDL_Renderer $renderer, Pointer[uint8] $r, Pointer[uint8] $g, Pointer[uint8] $b, Pointer[uint8] $a) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_GetRenderDrawColor(SDL_Renderer $renderer, Pointer[uint8] $r, Pointer[uint8] $g, Pointer[uint8] $b, Pointer[uint8] $a) returns int32 is native($lib) is export {*}
 
-sub SDL_RenderCopy(SDL_Renderer $renderer, SDL_Texture $src, SDL_Rect $srcrect, SDL_Rect $destrect) returns int32 is native($lib, v1.1.0) is export {*}
-sub SDL_RenderCopyEx(SDL_Renderer $renderer, SDL_Texture $src, SDL_Rect $srcrect, SDL_Rect $destrect, num32 $angle, SDL_Point32 $center, int32 $flip) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_RenderCopy(SDL_Renderer $renderer, SDL_Texture $src, SDL_Rect $srcrect, SDL_Rect $destrect) returns int32 is native($lib) is export {*}
+sub SDL_RenderCopyEx(SDL_Renderer $renderer, SDL_Texture $src, SDL_Rect $srcrect, SDL_Rect $destrect, num32 $angle, SDL_Point32 $center, int32 $flip) returns int32 is native($lib) is export {*}
 
-sub SDL_RenderClear(SDL_Renderer $renderer) returns int32 is native($lib, v1.1.0) is export {*}
-sub SDL_RenderPresent(SDL_Renderer $renderer) is native($lib, v1.1.0) is export {*}
+sub SDL_RenderClear(SDL_Renderer $renderer) returns int32 is native($lib) is export {*}
+sub SDL_RenderPresent(SDL_Renderer $renderer) is native($lib) is export {*}
 
-sub SDL_RenderDrawPoint(SDL_Renderer $renderer, int32 $x, int32 $y) returns int32 is native($lib, v1.1.0) is export {*}
-sub SDL_RenderDrawLine(SDL_Renderer $renderer, int32 $x, int32 $y, int32 $x2, int32 $y2) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_RenderDrawPoint(SDL_Renderer $renderer, int32 $x, int32 $y) returns int32 is native($lib) is export {*}
+sub SDL_RenderDrawLine(SDL_Renderer $renderer, int32 $x, int32 $y, int32 $x2, int32 $y2) returns int32 is native($lib) is export {*}
 
-sub SDL_RenderDrawRect(SDL_Renderer $renderer, SDL_Rect $rect) returns int32 is native($lib, v1.1.0) is export {*}
-sub SDL_RenderFillRect(SDL_Renderer $renderer, SDL_Rect $rect) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_RenderDrawRect(SDL_Renderer $renderer, SDL_Rect $rect) returns int32 is native($lib) is export {*}
+sub SDL_RenderFillRect(SDL_Renderer $renderer, SDL_Rect $rect) returns int32 is native($lib) is export {*}
 
 # Texture functions
 sub SDL_CreateTexture(SDL_Renderer $renderer, int32 $format, int32 $access, int32 $w, int32 $h)
         returns SDL_Texture
-        is native($lib, v1.1.0)
+        is native($lib)
         is export
         {*}
 
 sub SDL_UpdateTexture(SDL_Texture $tex, SDL_Rect $rect, Pointer $data, int32 $pitch)
         returns int32
-        is native($lib, v1.1.0)
+        is native($lib)
         is export
         {*}
 
 sub SDL_SetTextureBlendMode(SDL_Texture $tex, int32 $blendmode)
         returns int32
-        is native($lib, v1.1.0)
+        is native($lib)
         is export
         {*}
 
 sub SDL_GetTextureBlendMode(SDL_Texture $tex, Pointer[int32] $blendmode)
         returns int32
-        is native($lib, v1.1.0)
+        is native($lib)
         is export
         {*}
 
-sub SDL_SetTextureColorMod(SDL_Texture $texture, int8 $r, int8 $g, int8 $b) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_SetTextureColorMod(SDL_Texture $texture, int8 $r, int8 $g, int8 $b) returns int32 is native($lib) is export {*}
 
 sub SDL_SetRenderDrawBlendMode(SDL_Renderer $renderer, int32 $blendmode)
-        is native($lib, v1.1.0)
+        is native($lib)
         is export
         {*}
 
-sub SDL_DestroyTexture(SDL_Texture $texture) is native($lib, v1.1.0) is export {*}
-sub SDL_DestroyRenderer(SDL_Renderer $renderer) is native($lib, v1.1.0) is export {*}
+sub SDL_DestroyTexture(SDL_Texture $texture) is native($lib) is export {*}
+sub SDL_DestroyRenderer(SDL_Renderer $renderer) is native($lib) is export {*}
 
-sub SDL_VideoInit(Str $drivername) returns int32 is native($lib, v1.1.0) is export {*}
-sub SDL_VideoQuit() is native($lib, v1.1.0) is export {*}
+sub SDL_VideoInit(Str $drivername) returns int32 is native($lib) is export {*}
+sub SDL_VideoQuit() is native($lib) is export {*}
 
-sub SDL_GetNumVideoDrivers() returns int32 is native($lib, v1.1.0) is export {*}
-sub SDL_GetVideoDriver(int32 $index) returns Str is native($lib, v1.1.0) is export {*}
-sub SDL_GetCurrentVideoDriver() returns Str is native($lib, v1.1.0) is export {*}
+sub SDL_GetNumVideoDrivers() returns int32 is native($lib) is export {*}
+sub SDL_GetVideoDriver(int32 $index) returns Str is native($lib) is export {*}
+sub SDL_GetCurrentVideoDriver() returns Str is native($lib) is export {*}
 
-sub SDL_GetNumVideoDisplays() returns int32 is native($lib, v1.1.0) is export {*}
-sub SDL_GetDisplayName(int32 $index) returns Str is native($lib, v1.1.0) is export {*}
-sub SDL_GetDisplayBounds(int32 $index, SDL_Rect $rect) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_GetNumVideoDisplays() returns int32 is native($lib) is export {*}
+sub SDL_GetDisplayName(int32 $index) returns Str is native($lib) is export {*}
+sub SDL_GetDisplayBounds(int32 $index, SDL_Rect $rect) returns int32 is native($lib) is export {*}
 
 # GL Functions
-sub SDL_GL_BindTexture(SDL_Texture $texture, Pointer[num32] $texw, Pointer[num32] $texh) returns int32 is native($lib, v1.1.0) is export {*}
-sub SDL_GL_UnBindTexture(SDL_Texture $texture) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_GL_BindTexture(SDL_Texture $texture, Pointer[num32] $texw, Pointer[num32] $texh) returns int32 is native($lib) is export {*}
+sub SDL_GL_UnBindTexture(SDL_Texture $texture) returns int32 is native($lib) is export {*}
 
-sub SDL_GL_CreateContext(SDL_Window $window) returns SDL_GLContext is native($lib, v1.1.0) is export {*}
-sub SDL_GL_DeleteContext(SDL_GLContext $context) is native($lib, v1.1.0) is export {*}
-sub SDL_GL_MakeCurrent(SDL_Window $window, SDL_GLContext $context) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_GL_CreateContext(SDL_Window $window) returns SDL_GLContext is native($lib) is export {*}
+sub SDL_GL_DeleteContext(SDL_GLContext $context) is native($lib) is export {*}
+sub SDL_GL_MakeCurrent(SDL_Window $window, SDL_GLContext $context) returns int32 is native($lib) is export {*}
 
-sub SDL_GL_SetAttribute(int32 $attr, int32 $value) returns int32 is native($lib, v1.1.0) is export {*}
-sub SDL_GL_SwapWindow(SDL_Window $window) is native($lib, v1.1.0) is export {*}
+sub SDL_GL_SetAttribute(int32 $attr, int32 $value) returns int32 is native($lib) is export {*}
+sub SDL_GL_SwapWindow(SDL_Window $window) is native($lib) is export {*}
 
 # Event functions
-sub SDL_PollEvent(SDL_Event $event) returns int32 is native($lib, v1.1.0) is export {*}
-sub SDL_WaitEvent(SDL_Event $event) returns int32 is native($lib, v1.1.0) is export {*}
-sub SDL_WaitEventTimeout(SDL_Event $event, int32 $timeout) returns int32 is native($lib, v1.1.0) is export {*}
+sub SDL_PollEvent(SDL_Event $event) returns int32 is native($lib) is export {*}
+sub SDL_WaitEvent(SDL_Event $event) returns int32 is native($lib) is export {*}
+sub SDL_WaitEventTimeout(SDL_Event $event, int32 $timeout) returns int32 is native($lib) is export {*}
 
 sub SDL_CastEvent(SDL_Event $event) is export {
   given $event.type {
@@ -560,7 +571,7 @@ our constant SDL_IGNORE  =  0;
 our constant SDL_DISABLE =  0;
 our constant SDL_ENABLE  =  1;
 
-sub SDL_EventState(int32 $type, int32 $state) returns uint8 is native($lib, v1.1.0) is export {*}
+sub SDL_EventState(int32 $type, int32 $state) returns uint8 is native($lib) is export {*}
 
 my sub _pxfmt($type, $order, $layout, $bits, $bytes) {
     (1 +< 28) +| ($type +< 24) +| ($order +< 20) +| ($layout +< 16) +| ($bits +< 8) +| $bytes


### PR DESCRIPTION
This has a some more functions/events from SDL2 implemented.

Code has been moved around to theoretically be more organized.

Versions have been added to all the lib calls. (v1.1.0 used since I consider v1 to be the original code written by timo)

int/num removed for int32/num32 to be compatible with 6.c release.