### PR TITLE
Fix type mismatch in SDL_CreateTexture

### DIFF
--- a/lib/SDL2/Raw.pm6
+++ b/lib/SDL2/Raw.pm6
@@ -265,7 +265,7 @@ sub SDL_GetRendererInfo(SDL_Renderer $renderer, SDL_RendererInfo $info)
         is export
         {*}
 
-sub SDL_CreateTexture(SDL_Renderer $renderer, int32 $format, int32 $access, int32 $w, int32 $h)
+sub SDL_CreateTexture(SDL_Renderer $renderer, uint32 $format, int32 $access, int32 $w, int32 $h)
         returns SDL_Texture
         is native($lib)
         is export


### PR DESCRIPTION
According to the SDL2 wiki SDL_CreateTexture's format arg is a `UInt32`,
so we need to pass a `uint32`. The SDL2 module actually does this correctly
and fails, since Rakudo now distinguishes between int and uint.